### PR TITLE
Support for clickable links in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,11 @@
 
 - **🎨 Rich Diagrams** - Embed sequence diagrams, UML, flowcharts, and more directly in your code comments
 - **🔗 Smart Linking** - Automatic cross-references between types, both internal and external (to pkg.go.dev)
+- **📝 Auto-Linked Documentation** - Backtick references in comments automatically become clickable links
 - **📊 Visual Examples** - Render structs as JSON/YAML examples automatically
 - **✨ Syntax Highlighting** - Code highlighting with clickable type references
+- **🏗️ Multi-Module Support** - Full Go workspace support with flexible documentation generation
+- **📦 Package-Level Splitting** - Generate separate documentation files per package
 - **🎯 Flexible Templates** - Customize every aspect of your documentation output
 
 (see asciidoc [markup](https://asciidoctor.org/docs/asciidoc-writers-guide/) guide)
@@ -153,6 +156,113 @@ Options:
 ### Linking Referenced Types
 
 When generating documentation, `goasciidoc` can now render hyperlinks for referenced Go types. Enable it with `--type-links internal` to link across types within the current module, or `--type-links external` to also point at [`pkg.go.dev`](https://pkg.go.dev/) for external packages. By default (`--type-links disabled`) type names are rendered as plain text, preserving the behaviour of earlier releases.
+
+### Automatic Documentation Reference Linking
+
+`goasciidoc` automatically transforms backtick-enclosed identifiers in your documentation comments into clickable links! This works seamlessly with the `--type-links` flag to create rich, navigable documentation.
+
+#### How It Works
+
+Simply wrap any type, function, method, or package name in backticks within your Go documentation comments, and `goasciidoc` will automatically:
+
+1. **Detect** the reference in your documentation
+2. **Resolve** it using your file's imports
+3. **Generate** the appropriate link (internal anchor or external pkg.go.dev)
+
+#### Supported Reference Formats
+
+**Type References:**
+- `` `MyType` `` - Links to type in current package
+- `` `pkg.MyType` `` - Links to type from imported package
+- `` `github.com/user/repo/pkg.MyType` `` - Fully qualified type reference
+
+**Method References:**
+- `` `MyMethod` `` - Links to function in current package
+- `` `Employee.GetName` `` - Links to method on receiver type
+- `` `pkg.Service.Start` `` - Links to method from imported package
+
+**Function References:**
+- `` `Resolve` `` - Links to function in current package
+- `` `fmt.Println` `` - Links to external function (when using `--type-links external`)
+
+**Package References:**
+- `` `fmt` `` - Links to package documentation
+- `` `github.com/user/repo/pkg` `` - Links to specific package
+
+#### Example Usage
+
+```go
+package myapp
+
+import (
+    "fmt"
+    "github.com/myorg/models"
+)
+
+// Employee represents an employee in the system.
+// It provides methods for managing employee data.
+type Employee struct {
+    Name string
+    ID   int
+}
+
+// GetName returns the employee's name.
+// Use `fmt.Println` to display it.
+func (e *Employee) GetName() string {
+    return e.Name
+}
+
+// Person works in combination with the `Resolve` function to
+// resolve the `Employee` type. It uses the `fmt` package to
+// display information.
+//
+// The `Employee.GetName` method returns the employee name.
+// You can also use the `models.Manager` type for hierarchical structures.
+type Person struct {
+    Employee Employee
+    Age      int
+}
+
+// Resolve resolves a `Person` to an `Employee`.
+// This function works with `fmt.Sprint` internally.
+func Resolve(p *Person) *Employee {
+    return &p.Employee
+}
+```
+
+**Generated Documentation Links:**
+
+When using `--type-links internal-external`, the above documentation generates:
+
+- `` `Resolve` `` → Internal anchor link to the Resolve function
+- `` `Employee` `` → Internal anchor link to the Employee type
+- `` `Employee.GetName` `` → Internal anchor link to the GetName method
+- `` `fmt` `` → External link to https://pkg.go.dev/fmt
+- `` `fmt.Println` `` → External link to https://pkg.go.dev/fmt#Println
+- `` `fmt.Sprint` `` → External link to https://pkg.go.dev/fmt#Sprint
+- `` `models.Manager` `` → External link to https://pkg.go.dev/github.com/myorg/models#Manager
+
+#### Automatic Disambiguation
+
+`goasciidoc` is smart about resolving references:
+
+- **Package vs Type:** `` `fmt` `` is recognized as a package, `` `Employee` `` as a type
+- **Package vs Receiver:** `` `pkg.Method` `` checks imports; `` `Employee.GetName` `` checks current package types
+- **Standard Library:** Automatically recognized and linked to pkg.go.dev
+
+#### Usage
+
+Reference linking is automatically enabled when using type linking modes:
+
+```bash
+# Link both internal types and documentation references
+goasciidoc --type-links internal --highlighter goasciidoc
+
+# Link internal and external (recommended for comprehensive docs)
+goasciidoc --type-links internal-external --highlighter goasciidoc
+```
+
+**💡 Pro Tip:** Combine with `--highlighter goasciidoc` for syntax-highlighted function signatures that also include clickable type links!
 
 ### Multi-Module & Workspace Support
 

--- a/asciidoc/doclinks.go
+++ b/asciidoc/doclinks.go
@@ -1,0 +1,396 @@
+package asciidoc
+
+import (
+	"fmt"
+	"go/types"
+	"regexp"
+	"strings"
+
+	"github.com/mariotoffia/goasciidoc/goparser"
+	"golang.org/x/tools/go/packages"
+)
+
+// DocReference represents a parsed reference from documentation
+type DocReference struct {
+	Original     string  // Original text from backticks (e.g., "pkg.MyType")
+	PackagePath  string  // Full package import path (e.g., "github.com/user/pkg")
+	PackageAlias string  // Package alias or name used in reference
+	Receiver     string  // Struct/interface name for methods
+	Identifier   string  // Type/method/function/package name
+	Kind         RefKind // What this reference points to
+	IsExternal   bool    // Whether reference is to external package
+}
+
+type RefKind int
+
+const (
+	RefUnknown RefKind = iota
+	RefType        // Struct, interface, type alias, etc.
+	RefMethod      // Method on a type
+	RefFunction    // Package-level function
+	RefPackage     // Package reference
+	RefField       // Struct field
+	RefConstant    // Package-level constant
+	RefVariable    // Package-level variable
+)
+
+// backtickPattern matches content within backticks
+var backtickPattern = regexp.MustCompile("`([^`]+)`")
+
+// processDocumentation processes documentation strings and replaces backtick references with links
+func (t *TemplateContext) processDocumentation(doc string) string {
+	if doc == "" || t.Config == nil || t.Config.TypeLinks == TypeLinksDisabled {
+		return doc
+	}
+
+	return backtickPattern.ReplaceAllStringFunc(doc, func(match string) string {
+		// Extract content without backticks
+		content := strings.Trim(match, "`")
+		if content == "" {
+			return match
+		}
+
+		// Try to parse and resolve as a reference
+		ref := t.parseReference(content)
+		if ref == nil {
+			// Not a valid reference, return as-is
+			return match
+		}
+
+		// Try to resolve the reference
+		if !t.resolveReference(ref) {
+			// Could not resolve, return as-is
+			return match
+		}
+
+		// Generate link for the resolved reference
+		link := t.generateDocLink(ref)
+		if link == "" {
+			return match
+		}
+
+		return link
+	})
+}
+
+// parseReference parses a backtick reference into components
+func (t *TemplateContext) parseReference(ref string) *DocReference {
+	ref = strings.TrimSpace(ref)
+	if ref == "" {
+		return nil
+	}
+
+	// Check if it's a builtin type - don't link these
+	if _, ok := builtinTypes[ref]; ok {
+		return nil
+	}
+
+	dr := &DocReference{
+		Original: ref,
+		Kind:     RefUnknown,
+	}
+
+	// Split by dots
+	parts := strings.Split(ref, ".")
+
+	switch len(parts) {
+	case 1:
+		// Unqualified identifier: MyType, MyFunc, or package name
+		// We'll determine if it's a package during resolution
+		dr.Identifier = parts[0]
+
+	case 2:
+		// Could be:
+		// - pkg.Type (qualified type)
+		// - Receiver.Method (method on receiver)
+		// We'll determine which during resolution
+		// For now, set both and let resolution logic decide
+		dr.PackageAlias = parts[0]
+		dr.Receiver = parts[0] // Also set as potential receiver
+		dr.Identifier = parts[1]
+
+	case 3:
+		// pkg.Receiver.Method or nested package path
+		// We'll try both interpretations during resolution
+		dr.PackageAlias = parts[0]
+		dr.Receiver = parts[1]
+		dr.Identifier = parts[2]
+
+	default:
+		// Fully qualified path like github.com/user/pkg.Type
+		// or github.com/user/pkg.Receiver.Method
+		// Find where package path ends
+		dr.PackagePath, dr.Receiver, dr.Identifier = t.splitFullyQualifiedRef(ref, parts)
+		if dr.PackagePath != "" {
+			// Extract package alias from path
+			dr.PackageAlias = parts[len(parts)-2]
+			if dr.Receiver != "" {
+				dr.PackageAlias = parts[len(parts)-3]
+			}
+		}
+	}
+
+	return dr
+}
+
+// splitFullyQualifiedRef splits a fully qualified reference like github.com/user/pkg.Type
+func (t *TemplateContext) splitFullyQualifiedRef(ref string, parts []string) (pkgPath, receiver, identifier string) {
+	// Look for package path containing '/'
+	lastSlashIdx := strings.LastIndex(ref, "/")
+	if lastSlashIdx == -1 {
+		// No slash, not a full path
+		return "", "", ""
+	}
+
+	// Everything up to the last package component is the path
+	// Find the first '.' after the last '/'
+	dotAfterSlashIdx := strings.Index(ref[lastSlashIdx:], ".")
+	if dotAfterSlashIdx == -1 {
+		// No dot after slash, could be just a package reference
+		return ref, "", ""
+	}
+
+	dotAfterSlashIdx += lastSlashIdx
+	pkgPath = ref[:dotAfterSlashIdx]
+	rest := ref[dotAfterSlashIdx+1:]
+
+	// rest is either "Type" or "Receiver.Method"
+	dotIdx := strings.Index(rest, ".")
+	if dotIdx == -1 {
+		identifier = rest
+	} else {
+		receiver = rest[:dotIdx]
+		identifier = rest[dotIdx+1:]
+	}
+
+	return pkgPath, receiver, identifier
+}
+
+// resolveReference attempts to resolve a reference using imports and type information
+func (t *TemplateContext) resolveReference(ref *DocReference) bool {
+	if ref == nil {
+		return false
+	}
+
+	// Special case: single identifier that might be a package name
+	// Check if it's in the imports
+	if ref.PackageAlias == "" && ref.Receiver == "" && ref.Identifier != "" {
+		if pkgPath := t.importPathForAlias(ref.Identifier, t.File); pkgPath != "" {
+			// It's a package reference
+			ref.PackagePath = pkgPath
+			ref.PackageAlias = ref.Identifier
+			ref.Identifier = "" // Clear identifier to mark as package-only
+		}
+	}
+
+	// For two-part references, determine if first part is package or receiver
+	if ref.PackageAlias != "" && ref.Receiver != "" && ref.PackageAlias == ref.Receiver {
+		// Both are set to the same value, need to disambiguate
+		if pkgPath := t.importPathForAlias(ref.PackageAlias, t.File); pkgPath != "" {
+			// It's a package reference (pkg.Type or pkg.Function)
+			ref.PackagePath = pkgPath
+			ref.Receiver = "" // Clear receiver
+		} else {
+			// It's likely a receiver reference (Type.Method)
+			ref.PackageAlias = "" // Clear package alias
+			// Keep receiver and use current package
+		}
+	}
+
+	// Now resolve package path if not already set
+	if ref.PackagePath == "" && ref.PackageAlias != "" {
+		ref.PackagePath = t.resolvePackagePath(ref.PackageAlias)
+	}
+
+	// If still no package path and we have an identifier (not package-only ref),
+	// use current file's package
+	if ref.PackagePath == "" && ref.Identifier != "" && t.File != nil {
+		ref.PackagePath = t.packagePathForFile(t.File)
+	}
+
+	// Determine if this is internal or external
+	if ref.PackagePath != "" {
+		// Standard library packages (no dots/slashes) are always external
+		if !strings.Contains(ref.PackagePath, ".") && !strings.Contains(ref.PackagePath, "/") {
+			ref.IsExternal = true
+		} else {
+			ref.IsExternal = !t.isInternalImport(ref.PackagePath)
+		}
+	}
+
+	// Try to determine the kind of reference
+	// For external references, we'll make best-effort guesses
+	if ref.IsExternal {
+		// For external refs, guess based on naming conventions
+		if ref.Receiver != "" {
+			ref.Kind = RefMethod
+		} else if ref.PackageAlias == "" && ref.PackagePath != "" && ref.Identifier == "" {
+			ref.Kind = RefPackage
+		} else if ref.Identifier != "" {
+			// Could be type or function - default to type
+			ref.Kind = RefType
+		}
+		return true
+	}
+
+	// For internal references, try to actually resolve using type information
+	// This is best-effort - if we can't load package info, we'll still generate links
+	return t.resolveInternalReference(ref)
+}
+
+// resolvePackagePath resolves a package alias to a full import path
+func (t *TemplateContext) resolvePackagePath(alias string) string {
+	// Try to resolve from imports
+	if path := t.importPathForAlias(alias, t.File); path != "" {
+		return path
+	}
+
+	// Check if it's a standard library package (no dots in name)
+	if !strings.Contains(alias, ".") && !strings.Contains(alias, "/") {
+		// Likely a standard library package like "fmt", "os", etc.
+		return alias
+	}
+
+	// Could be a package name without import (same package)
+	// or a reference that doesn't resolve
+	return ""
+}
+
+// resolveInternalReference attempts to resolve an internal reference using type information
+func (t *TemplateContext) resolveInternalReference(ref *DocReference) bool {
+	// For now, we'll do basic resolution based on naming
+	// Full type checking would require loading package information
+
+	if ref.Receiver != "" {
+		// Has receiver, likely a method
+		ref.Kind = RefMethod
+		return true
+	}
+
+	if ref.Identifier == "" {
+		// No identifier, likely a package reference
+		ref.Kind = RefPackage
+		return true
+	}
+
+	// Check if identifier starts with uppercase (exported)
+	if len(ref.Identifier) > 0 {
+		first := rune(ref.Identifier[0])
+		if first >= 'A' && first <= 'Z' {
+			// Could be Type, Function, Constant, or Variable
+			// Default to Type as it's most common in docs
+			ref.Kind = RefType
+			return true
+		}
+	}
+
+	// Lowercase, less common in docs but could be unexported type/function
+	ref.Kind = RefType
+	return true
+}
+
+// generateDocLink generates an AsciiDoc link for a resolved reference
+func (t *TemplateContext) generateDocLink(ref *DocReference) string {
+	if ref == nil || ref.PackagePath == "" {
+		return ""
+	}
+
+	linkText := ref.Original
+
+	// Handle package-only references
+	if ref.Kind == RefPackage {
+		if ref.IsExternal {
+			if t.Config.TypeLinks == TypeLinksInternalExternal {
+				return fmt.Sprintf("link:https://pkg.go.dev/%s[%s]", ref.PackagePath, linkText)
+			}
+			return "`" + linkText + "`"
+		}
+		// Internal package reference - link to package anchor
+		anchor := anchorID(ref.PackagePath, "")
+		return fmt.Sprintf("<<%s,%s>>", strings.TrimSuffix(anchor, "."), linkText)
+	}
+
+	// Build anchor ID
+	var anchor string
+	if ref.Receiver != "" {
+		// Method reference: pkg.Receiver.Method
+		anchor = anchorID(ref.PackagePath, ref.Receiver+"."+ref.Identifier)
+	} else {
+		// Type/Function reference: pkg.Identifier
+		anchor = anchorID(ref.PackagePath, ref.Identifier)
+	}
+
+	// Generate link based on internal/external and mode
+	if ref.IsExternal {
+		if t.Config.TypeLinks == TypeLinksInternalExternal {
+			return t.generateExternalLink(ref, linkText)
+		}
+		// External but not linking external refs
+		return "`" + linkText + "`"
+	}
+
+	// Internal reference
+	return t.generateInternalLink(ref, anchor, linkText)
+}
+
+// generateExternalLink creates a pkg.go.dev link
+func (t *TemplateContext) generateExternalLink(ref *DocReference, linkText string) string {
+	switch ref.Kind {
+	case RefPackage:
+		return fmt.Sprintf("link:https://pkg.go.dev/%s[%s]", ref.PackagePath, linkText)
+
+	case RefMethod:
+		if ref.Receiver != "" {
+			return fmt.Sprintf("link:https://pkg.go.dev/%s#%s.%s[%s]",
+				ref.PackagePath, ref.Receiver, ref.Identifier, linkText)
+		}
+		return fmt.Sprintf("link:https://pkg.go.dev/%s#%s[%s]",
+			ref.PackagePath, ref.Identifier, linkText)
+
+	case RefType, RefFunction, RefConstant, RefVariable:
+		return fmt.Sprintf("link:https://pkg.go.dev/%s#%s[%s]",
+			ref.PackagePath, ref.Identifier, linkText)
+
+	default:
+		return fmt.Sprintf("link:https://pkg.go.dev/%s#%s[%s]",
+			ref.PackagePath, ref.Identifier, linkText)
+	}
+}
+
+// generateInternalLink creates an internal AsciiDoc link
+func (t *TemplateContext) generateInternalLink(ref *DocReference, anchor, linkText string) string {
+	// Check if this is a cross-module reference in separate mode
+	if t.Config.SubModuleMode == SubModuleSeparate && t.isWorkspaceImport(ref.PackagePath) {
+		// Cross-module reference - use file link
+		targetModule := t.Workspace.ModuleForPath(ref.PackagePath)
+		if targetModule != nil {
+			shortName := goparser.ModuleShortName(targetModule)
+			return fmt.Sprintf("link:%s.adoc#%s[%s]", shortName, anchor, linkText)
+		}
+	}
+
+	// Same module or single/merged mode - use anchor link
+	return fmt.Sprintf("<<%s,%s>>", anchor, linkText)
+}
+
+// loadPackageTypes loads type information for a package
+func (t *TemplateContext) loadPackageTypes(pkgPath string) (*types.Package, error) {
+	cfg := &packages.Config{
+		Mode: packages.NeedTypes | packages.NeedName | packages.NeedImports,
+	}
+
+	pkgs, err := packages.Load(cfg, pkgPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(pkgs) == 0 {
+		return nil, fmt.Errorf("package not found: %s", pkgPath)
+	}
+
+	if pkgs[0].Types == nil {
+		return nil, fmt.Errorf("no type information for package: %s", pkgPath)
+	}
+
+	return pkgs[0].Types, nil
+}

--- a/asciidoc/template.go
+++ b/asciidoc/template.go
@@ -105,6 +105,9 @@ var defaultTemplateFuncs = texttemplate.FuncMap{
 	"toYAML": func(s *goparser.GoStruct) string {
 		return s.ToYAML()
 	},
+	"processReferences": func(t *TemplateContext, doc string) string {
+		return t.processDocumentation(doc)
+	},
 }
 
 // TemplateAndText is a wrapper of _template.Template_

--- a/asciidoc/templatecontext.go
+++ b/asciidoc/templatecontext.go
@@ -9,7 +9,8 @@ import (
 	"github.com/mariotoffia/goasciidoc/goparser"
 )
 
-// PackageRef represents a reference to another package
+// PackageRef represents a reference to another package.
+// It is used by `PackageReferences` to list internal and external package dependencies.
 type PackageRef struct {
 	// Name is the package name/path
 	Name string
@@ -307,7 +308,10 @@ func (t *TemplateContext) RenderReceiverFunctions(wr io.Writer, receiver string)
 }
 
 // RenderFunction will render a single function section onto the provided writer.
-func (t *TemplateContext) RenderFunction(wr io.Writer, f *goparser.GoStructMethod) *TemplateContext {
+func (t *TemplateContext) RenderFunction(
+	wr io.Writer,
+	f *goparser.GoStructMethod,
+) *TemplateContext {
 
 	q := t.Clone(true /*clean*/)
 	q.Function = f
@@ -376,7 +380,10 @@ func (t *TemplateContext) RenderVarTypeDefs(wr io.Writer) *TemplateContext {
 }
 
 // RenderVarTypeDef will render a single variable typedef section onto the provided writer.
-func (t *TemplateContext) RenderVarTypeDef(wr io.Writer, td *goparser.GoCustomType) *TemplateContext {
+func (t *TemplateContext) RenderVarTypeDef(
+	wr io.Writer,
+	td *goparser.GoCustomType,
+) *TemplateContext {
 
 	q := t.Clone(true /*clean*/)
 	q.TypeDefVar = td
@@ -399,7 +406,10 @@ func (t *TemplateContext) RenderVarDeclarations(wr io.Writer) *TemplateContext {
 }
 
 // RenderVarDeclaration will render a single variable declaration section onto the provided writer.
-func (t *TemplateContext) RenderVarDeclaration(wr io.Writer, a *goparser.GoAssignment) *TemplateContext {
+func (t *TemplateContext) RenderVarDeclaration(
+	wr io.Writer,
+	a *goparser.GoAssignment,
+) *TemplateContext {
 
 	q := t.Clone(true /*clean*/)
 	q.VarAssignment = a
@@ -422,7 +432,10 @@ func (t *TemplateContext) RenderConstDeclarations(wr io.Writer) *TemplateContext
 }
 
 // RenderConstDeclaration will render a single const declaration section onto the provided writer.
-func (t *TemplateContext) RenderConstDeclaration(wr io.Writer, a *goparser.GoAssignment) *TemplateContext {
+func (t *TemplateContext) RenderConstDeclaration(
+	wr io.Writer,
+	a *goparser.GoAssignment,
+) *TemplateContext {
 
 	q := t.Clone(true /*clean*/)
 	q.ConstAssignment = a

--- a/defaults/const.gtpl
+++ b/defaults/const.gtpl
@@ -3,4 +3,4 @@
 ----
 {{.ConstAssignment.Decl}}
 ----
-{{.ConstAssignment.Doc}}
+{{processReferences . .ConstAssignment.Doc}}

--- a/defaults/function.gtpl
+++ b/defaults/function.gtpl
@@ -32,7 +32,7 @@
 {{- end }}
 
 {{ if .Function.Doc }}
-{{ .Function.Doc }}
+{{ processReferences . .Function.Doc }}
 {{ end }}
 
 {{ if and ($sig) .Config.IncludeMethodCode }}{{"\n"}}[source, go]{{"\n"}}----{{"\n"}}{{ .Function.FullDecl }}{{"\n"}}----{{end}}

--- a/defaults/interface.gtpl
+++ b/defaults/interface.gtpl
@@ -11,7 +11,7 @@
 {{- end}}
 }
 ----
-{{- $ifaceDoc := trimnl .Interface.Doc -}}
+{{- $ifaceDoc := trimnl (processReferences . .Interface.Doc) -}}
 {{if $ifaceDoc}}
 {{printf "\n%s\n\n" $ifaceDoc}}
 {{else}}
@@ -38,7 +38,7 @@
 {{- printf "\n" -}}
 {{- end}}
 {{- range .Interface.Methods}}{{- if or .Exported $.Config.Private }}
-{{- $doc := trimnl .Doc -}}
+{{- $doc := trimnl (processReferences $ .Doc) -}}
 {{- if $doc }}
 {{- $sig := methodSignatureDoc $ . $.Interface.TypeParams -}}
 {{- $style := $.Config.SignatureStyle -}}

--- a/defaults/package.gtpl
+++ b/defaults/package.gtpl
@@ -19,4 +19,4 @@
 ====
 {{end}}
 
-{{if (index .Docs "package-overview")}}include::{{index .Docs "package-overview"}}[leveloffset=+1]{{"\n"}}{{else}}{{ .File.Doc }}{{"\n"}}{{end}}
+{{if (index .Docs "package-overview")}}include::{{index .Docs "package-overview"}}[leveloffset=+1]{{"\n"}}{{else}}{{ processReferences . .File.Doc }}{{"\n"}}{{end}}

--- a/defaults/receivers.gtpl
+++ b/defaults/receivers.gtpl
@@ -32,7 +32,7 @@
 {{- end }}
 
 {{- if .Doc }}
-{{.Doc}}
+{{processReferences $ .Doc}}
 {{- end }}
 
 {{end}}{{end}}

--- a/defaults/struct.gtpl
+++ b/defaults/struct.gtpl
@@ -8,7 +8,7 @@
 {{- end}}
 }
 ----
-{{- $structDoc := trimnl .Struct.Doc -}}
+{{- $structDoc := trimnl (processReferences . .Struct.Doc) -}}
 {{if $structDoc}}
 {{printf "\n%s\n\n" $structDoc}}
 {{else}}
@@ -65,7 +65,7 @@
 {{- range .Struct.Fields}}
 {{- if not .AnonymousStruct}}
 {{- if or .Exported $.Config.Private }}
-{{- $doc := trimnl .Doc -}}
+{{- $doc := trimnl (processReferences $ .Doc) -}}
 {{- if $doc }}
 {{printf "==== %s\n\n" (fieldHeading $ .)}}
 {{printf "%s\n\n" $doc}}

--- a/defaults/typedeffunc.gtpl
+++ b/defaults/typedeffunc.gtpl
@@ -31,4 +31,4 @@
 {{ printf "\n" }}
 {{- end }}
 {{- end }}
-{{.TypeDefFunc.Doc}}
+{{processReferences . .TypeDefFunc.Doc}}

--- a/defaults/typedefvar.gtpl
+++ b/defaults/typedefvar.gtpl
@@ -5,6 +5,6 @@
 {{.TypeDefVar.Decl}}
 ----
 
-{{.TypeDefVar.Doc}}
+{{processReferences . .TypeDefVar.Doc}}
 
 {{if hasReceivers . .TypeDefVar.Name}}{{renderReceivers . .TypeDefVar.Name}}{{end}}

--- a/defaults/var.gtpl
+++ b/defaults/var.gtpl
@@ -3,4 +3,4 @@
 ----
 {{.VarAssignment.Decl}}
 ----
-{{.VarAssignment.Doc}}
+{{processReferences . .VarAssignment.Doc}}


### PR DESCRIPTION
This PR makes it possible to reference types, interfaces, structs and packages from the documentation. It will interpret a `nnn` as a suggestion to create a link. If it is not resolvable from the current file imports it will be ignored.

This closes Issue #3 